### PR TITLE
Fix startup crash without API key and validate WebSocket inputs

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -49,9 +49,17 @@ app.use(cors({
 }));
 app.use(express.json({ limit: '10mb' }));
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY
-});
+// Don't crash at startup when the key is missing; AI features fail gracefully instead
+const openai = process.env.OPENAI_API_KEY
+  ? new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
+  : null;
+
+function requireOpenAI() {
+  if (!openai) {
+    throw new Error('OpenAI API key not configured. Set OPENAI_API_KEY to enable AI features.');
+  }
+  return openai;
+}
 
 const sessions = new Map();
 
@@ -109,7 +117,7 @@ Be helpful, encouraging, and specific about what you observe in the drawings.`
         ]
       });
 
-      const response = await openai.chat.completions.create({
+      const response = await requireOpenAI().chat.completions.create({
         model: 'gpt-4o',
         messages: messages,
         max_tokens: 800,
@@ -173,7 +181,7 @@ Be helpful, encouraging, and specific about what you observe in the drawings.`
         });
       }
 
-      const response = await openai.chat.completions.create({
+      const response = await requireOpenAI().chat.completions.create({
         model: includeCanvas ? 'gpt-4o' : 'gpt-4-turbo-preview',
         messages: messages,
         max_tokens: includeCanvas ? 800 : 500,
@@ -191,6 +199,13 @@ Be helpful, encouraging, and specific about what you observe in the drawings.`
         role: 'assistant',
         content: aiResponse
       });
+
+      if (this.conversationHistory.length > 21) {
+        this.conversationHistory = [
+          this.conversationHistory[0],
+          ...this.conversationHistory.slice(-20)
+        ];
+      }
 
       return aiResponse;
 
@@ -220,6 +235,13 @@ wss.on('connection', (ws) => {
       
       switch (message.type) {
         case 'canvas_update': {
+          if (typeof message.imageData !== 'string' || !message.imageData) {
+            ws.send(JSON.stringify({
+              type: 'error',
+              message: 'canvas_update requires imageData'
+            }));
+            break;
+          }
           session.addCanvasSnapshot(message.imageData);
           ws.send(JSON.stringify({
             type: 'ack',
@@ -229,6 +251,13 @@ wss.on('connection', (ws) => {
         }
 
         case 'analyze_canvas': {
+          if (typeof message.imageData !== 'string' || !message.imageData) {
+            ws.send(JSON.stringify({
+              type: 'error',
+              message: 'analyze_canvas requires imageData'
+            }));
+            break;
+          }
           const analysis = await session.analyzeCanvas(
             message.imageData,
             message.userMessage
@@ -243,6 +272,13 @@ wss.on('connection', (ws) => {
         }
 
         case 'chat_message': {
+          if (typeof message.content !== 'string' || !message.content.trim()) {
+            ws.send(JSON.stringify({
+              type: 'error',
+              message: 'chat_message requires non-empty content'
+            }));
+            break;
+          }
           const needsCanvas = message.includeCanvas || shouldUseVision(message.content);
           const response = await session.sendMessage(
             message.content,

--- a/server/server.js
+++ b/server/server.js
@@ -235,7 +235,7 @@ wss.on('connection', (ws) => {
       
       switch (message.type) {
         case 'canvas_update': {
-          if (typeof message.imageData !== 'string' || !message.imageData) {
+          if (typeof message.imageData !== 'string' || !message.imageData.trim()) {
             ws.send(JSON.stringify({
               type: 'error',
               message: 'canvas_update requires imageData'
@@ -251,7 +251,7 @@ wss.on('connection', (ws) => {
         }
 
         case 'analyze_canvas': {
-          if (typeof message.imageData !== 'string' || !message.imageData) {
+          if (typeof message.imageData !== 'string' || !message.imageData.trim()) {
             ws.send(JSON.stringify({
               type: 'error',
               message: 'analyze_canvas requires imageData'


### PR DESCRIPTION
## Testing summary

- Installed root + `server/` dependencies (0 vulnerabilities), ran ESLint (no findings; root config is empty), and `node --check` on all JS files (pass).
- Started the MCP server and smoke-tested HTTP endpoints: `GET /health` and `GET /stats` return correct JSON, unknown routes return 404, malformed JSON bodies return 400.
- Exercised WebSocket edge cases: invalid JSON frames, unknown message types, `ping`, and messages with missing required fields.

## Bugs found and fixed

1. **Startup crash without `OPENAI_API_KEY`** — the server threw at module load (`new OpenAI(...)`) when the key was unset, even though the startup banner is designed to report "API Key: ✗ Missing". The client is now created lazily; `/health`, `/stats`, and non-AI WebSocket messages work without a key, and AI requests return a clear "OpenAI API key not configured" error.
2. **Internal TypeError leaked to clients** — `chat_message` with a missing/non-string `content` surfaced `Cannot read properties of undefined (reading 'toLowerCase')` over the socket. Content is now validated with a descriptive error.
3. **Missing `imageData` validation** — `canvas_update` and `analyze_canvas` accepted messages without `imageData` (pushing `undefined` into canvas history). Both now respond with a clear error.
4. **Unbounded memory growth** — `sendMessage` never trimmed `conversationHistory` (only `analyzeCanvas` did), so long chat sessions grew without limit. The same 21-message trim is now applied.

All fixes re-verified by restarting the server (no key set) and replaying the edge-case messages: each now returns a descriptive error and the server stays healthy.

https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pdr2u5eE9XswikXHCjZNs5)_